### PR TITLE
Remove deprecated options from rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,11 +11,7 @@ export default {
     sourcemap: true
   },
   plugins: [
-    resolve({
-      jsnext: true,
-      main: true,
-      browser: true
-    }),
+    resolve(),
     commonjs(),
     uglify()
   ]


### PR DESCRIPTION
Default options are working fine